### PR TITLE
Remove redundancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,3 @@ If you don't already have it, you will need Node.js & npm:
 curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 sudo apt install nodejs
 ```
-
-and git:
-
-```bash
-sudo apt install git
-```


### PR DESCRIPTION
I don't think it's necessary to explicitly state to install git at the end, given that step one is to clone the repository using git.